### PR TITLE
Set initial k_M and k_K guesses to 1.2

### DIFF
--- a/app/approximation.py
+++ b/app/approximation.py
@@ -57,9 +57,9 @@ def configure_logging() -> None:
 
 @dataclass
 class ModelParameters:
-    k_M: float = 1.0
+    k_M: float = 1.2
     k_m: float = 1.0
-    k_K: float = 1.0
+    k_K: float = 1.2
     alpha: float = ALPHA_DEFAULT
 
     def as_array(self) -> np.ndarray:
@@ -203,7 +203,7 @@ def _append_residual(
 def fit_parameters(initial: ModelParameters | None = None, data_dir: Path | None = None) -> tuple[ModelParameters, List[ParsedSeries]]:
     data_root = data_dir or DATA_DIR
     observations, parsed_series = _build_observations_and_series(data_root)
-    p0 = initial.as_array() if initial else np.array([1.0, 1.0, 1.0, ALPHA_DEFAULT], dtype=float)
+    p0 = initial.as_array() if initial else np.array([1.2, 1.0, 1.2, ALPHA_DEFAULT], dtype=float)
     bounds = ([0.1, 0.1, 0.1, 1e-5], [10.0, 10.0, 10.0, 0.05])
 
     logger.info("Запуск подбора параметров: p0=%s", p0)


### PR DESCRIPTION
## Summary
- update default model parameters to start k_M and k_K at 1.2
- align default optimization initial guess with the new parameter defaults

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd80ba4848330860abf0c8e3c86c2)