### PR TITLE
Save theoretical curves to .npy files in repository root

### DIFF
--- a/app/approximation.py
+++ b/app/approximation.py
@@ -415,6 +415,23 @@ def _prepare_phase_diagram(params: ModelParameters, phase_data: PhaseDataset | N
     )
 
 
+def _save_theoretical_curves(series: Sequence[SeriesData], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for dataset in series:
+        output_path = output_dir / f"{dataset.name}.npy"
+        payload = np.vstack(
+            [
+                dataset.model_axis,
+                dataset.model_hf,
+                dataset.model_lf,
+                dataset.model_hf_tau,
+                dataset.model_lf_tau,
+            ]
+        )
+        np.save(output_path, payload)
+        logger.info("Сохранены теоретические кривые %s", output_path.name)
+
+
 def _parse_excel_table(path: Path) -> ParsedSeries:
     """
     Читает Excel-файл с данными по одному срезу (H = const или T = const).
@@ -596,6 +613,7 @@ def main(data_dir: str | None = None) -> None:
         )
 
         series = _prepare_series(best, parsed_series)
+        _save_theoretical_curves(series, BASE_DIR)
         phase_diagram = _prepare_phase_diagram(best, phase_data)
         fig = build_summary_figure(series, phase_diagram=phase_diagram)
         fig.show()


### PR DESCRIPTION
### Motivation
- Provide machine-readable outputs of the computed theoretical curves so each series can be post-processed or compared later.
- Save outputs next to `main.py` with a predictable filename pattern matching series names.

### Description
- Added `_save_theoretical_curves(series, output_dir: Path)` which stacks and writes per-series arrays with `np.save` into `output_dir`.
- The saved payload rows are ordered as `model_axis`, `model_hf`, `model_lf`, `model_hf_tau`, `model_lf_tau` to match the requested format and are written to files named `{series.name}.npy` in the repo root (`BASE_DIR`).
- The save routine logs each written file with `logger.info` for traceability.
- Wired the saver into the main flow by calling `_save_theoretical_curves(series, BASE_DIR)` after preparing `series` in `main()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966dc14ee8083308a8de6ed5ba5049e)